### PR TITLE
Bezel, BGM, and Hursty Themes Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,17 @@ I am useing there work in my script.
 - ~~Set Volume for BGM~~
 - Add Icon for Bezel Project in RetroPie config menu
 
+## Known Issues ##
+- When installing BGM the original BGM_Install.sh replaces the gamelist.xml removeing any other custom menu adds. 
+- ~~When installing Hursty Themes gamelist.xml not updated because scripts folder already existed~~
+
+
 ## Change Log
+
+**2/3/19**
+Added: Bezel install now updates gamelist.xml 
+Change: BGM function dowlnload busic if the ~/BGM folder doesn't exist
+Fixed: Hursty Themes original instal.sh crash due to scripts folder already existing, stopped using install.sh from            Hursty added to this script to check for the existance of folder. 
 
 **2/2/19**
 - Added: Hursty Themes Installer

--- a/RetroPieToolkit.sh
+++ b/RetroPieToolkit.sh
@@ -359,7 +359,11 @@ function bgm_sh(){
     if [[ "$testbgm" == *"BGM.py"* ]]; then
         dialog --infobox "BGM already installed" 3 30 ; sleep 3
     else
-        tar -zxvf ./BGM.tar.gz -C ../ &> /dev/null
+        if [ ! -d "~/BGM/" ]; then
+            cd /tmp
+            wget https://github.com/dipstah/RetroPie-Toolkit/raw/master/BGM.tar.gz
+            tar -zxvf ./BGM.tar.gz -C ~/ &> /dev/null
+        fi
         sudo cp --backup=numbered -v /etc/rc.local ~/rpicfgbackup &> /dev/null
         cd ~/
         #git clone https://github.com/madmodder123/retropie_music_overlay.git
@@ -455,10 +459,47 @@ function bezelproject(){
     --title "RetroPie Toolkit Bezel Project" \
     --msgbox "${infoboxbezel}" 10 75
     
+    bezelproject_sh
+    infoboxbezel=
+}
+function bezelproject_sh(){
+    if [ ! -d "~/rpicfgbackup" ]; then
+        sudo mkdir -p ~/rpicfgbackup &> /dev/null
+    fi
+    
+    sudo cp --backup=numbered -v /opt/retropie/configs/all/emulationstation/gamelists/retropie/gamelist.xml  ~/rpicfgbackup &> /dev/null
     cd /home/pi/RetroPie/retropiemenu/
 	wget https://raw.githubusercontent.com/thebezelproject/BezelProject/master/bezelproject.sh
 	chmod +x "bezelproject.sh"
-    infoboxbezel=
+    
+    if [ -f ~/RetroPie/retropiemenu/gamelist.xml ]; then
+        cp ~/RetroPie/retropiemenu/gamelist.xml /tmp
+    else
+        cp /opt/retropie/configs/all/emulationstation/gamelists/retropie/gamelist.xml /tmp
+    fi
+    
+    if [ ! -f ~/RetroPie/retropiemenu/icons/BezelProject.png ]; then
+        cd /tmp
+        wget https://github.com/dipstah/RetroPie-Toolkit/raw/master/icons.tar.gz
+        tar -zxvf ./icons.tar.gz -C ~/RetroPie/retropiemenu/ &> /dev/null 
+    fi
+    cat /tmp/gamelist.xml |grep -v "</gameList>" > /tmp/templist.xml
+
+    ifexist=`cat /tmp/templist.xml |grep bezelproject |wc -l`
+    if [[ ${ifexist} > 0 ]]; then
+        echo "already in gamelist.xml" > /tmp/exists
+    else
+        echo "	<game>" >> /tmp/templist.xml
+        echo "      <path>./bezelproject.sh</path>" >> /tmp/templist.xml
+        echo "      <name>Bezel Project</name>" >> /tmp/templist.xml
+        echo "      <desc>This utility provides a download for a bezel pack for a system and includes a PNG bezel file for every ROM for that system. The download will also include the necessary configuration files needed for Retroarch to show them. The script will also update the required retroarch.cfg files for the emulators located in the /opt/retropie/configs directory. These changes are necessary to show the PNG bezels with an opacity of 1.</desc>" >> /tmp/templist.xml
+        echo "      <image>./icons/BezelProject.png</image>" >> /tmp/templist.xml
+        echo "      <playcount>1</playcount>" >> /tmp/templist.xml
+        echo "      <lastplayed></lastplayed>" >> /tmp/templist.xml
+        echo "  </game>" >> /tmp/templist.xml
+        echo "</gameList>" >> /tmp/templist.xml
+        cp /tmp/templist.xml ~/RetroPie/retropiemenu/gamelist.xml
+    fi        
 }
 
 function hurstythemes(){
@@ -475,9 +516,51 @@ function hurstythemes(){
     --title "RetroPie Toolkit Hursty Themes" \
     --msgbox "${infoboxhursty}" 12 75
     
-    wget https://raw.githubusercontent.com/RetroHursty69/HurstyThemes/master/install.sh
-    chmod +x "install.sh"
-    ./install.sh
+    #wget https://raw.githubusercontent.com/RetroHursty69/HurstyThemes/master/install.sh
+    #chmod +x "install.sh"
+    #./install.sh   
+    rm -rf "/tmp/hursty"
+    mkdir -p "/tmp/hursty"
+    git clone "https://github.com/RetroHursty69/HurstyThemes.git" "/tmp/hursty"
+
+    # Move files to proper directory
+
+    cp /tmp/hursty/hurstythemes.sh /home/pi/RetroPie/retropiemenu
+    chmod 777 /home/pi/RetroPie/retropiemenu/hurstythemes.sh
+    cp /tmp/hursty/hurstythemes.png /home/pi/RetroPie/retropiemenu/icons
+    if [ ! -d ~/scripts ]; then
+        mkdir /home/pi/scripts
+    fi
+    cp /tmp/hursty/themerandom.sh /home/pi/scripts
+    chmod 777 /home/pi/scripts/themerandom.sh
+
+    # Update RetroPie gamelist.xml to add new entry
+
+    if [ -f ~/RetroPie/retropiemenu/gamelist.xml ]; then
+        sudo cp --backup=numbered -v ~/RetroPie/retropiemenu/gamelist.xml ~/rpicfgbackup &> /dev/null
+        cp ~/RetroPie/retropiemenu/gamelist.xml /tmp
+    else
+        sudo cp --backup=numbered -v /opt/retropie/configs/all/emulationstation/gamelists/retropie/gamelist.xml  ~/rpicfgbackup &> /dev/null
+        cp /opt/retropie/configs/all/emulationstation/gamelists/retropie/gamelist.xml /tmp
+    fi
+
+    cat /tmp/gamelist.xml |grep -v "</gameList>" > /tmp/templist.xml
+
+    ifexist=`cat /tmp/templist.xml |grep hurstythemes |wc -l`
+    if [[ ${ifexist} > 0 ]]; then
+        echo "already in gamelist.xml" > /tmp/exists
+    else
+        echo "    <game>" >> /tmp/templist.xml
+        echo "        <path>./hurstythemes.sh</path>" >> /tmp/templist.xml
+        echo "        <name>Hursty's Themes</name>" >> /tmp/templist.xml
+        echo "        <desc>Install, uninstall, or update RetroHursty69's EmulationStation themes. It also includes an ES bootup theme randomizer to automatically switch themes on bootup.</desc>" >> /tmp/templist.xml
+        echo "        <image>./icons/hurstythemes.png</image>" >> /tmp/templist.xml
+        echo "        <playcount>1</playcount>" >> /tmp/templist.xml
+        echo "        <lastplayed></lastplayed>" >> /tmp/templist.xml
+        echo "    </game>" >> /tmp/templist.xml
+        echo "</gameList>" >> /tmp/templist.xml
+        cp /tmp/templist.xml ~/RetroPie/retropiemenu/gamelist.xml
+    fi
     infoboxhursty=
 }
 main_menu 


### PR DESCRIPTION
Added: Bezel install now updates gamelist.xml
Change: BGM function dowlnload busic if the ~/BGM folder doesn't exist
Fixed: Hursty Themes original instal.sh crash due to scripts folder already existing, stopped using install.sh from HurstyThemes added to this script to check for the existence of folder.

@RetroHursty69 
- When installing HurstyThemes gamelist.xml not updated because scripts folder already existed would cause install.sh to exit
@madmodder123
- When installing BGM the original BGM_Install.sh replaces the gamelist.xml removeing any other custom menu adds. 

