### PR TITLE
Install to RetroPie

### DIFF
--- a/BGM_Toggle.sh
+++ b/BGM_Toggle.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
-# BGM_Toggle.sh
-#############################################
-# Lets the user enable/disable the background music
-#############################################
+
+###################################################################
+#Script Name	: BGM_Toggle.sh
+#Description    :Script for enabling/disabling Background Music replaced 
+#                @madmodder123 original BGM_Toggle.sh for BGM
+#https://github.com/dipstah/RetroPie-Toolkit
+#madmodder123 BGM https://github.com/madmodder123/retropie_music_overlay
+#Author         :Mike White
+#Email         	:dipstah@dippydawg.net
+###################################################################
 function mainmenu(){
     if [ -f ~/DisableMusic ]; then
         bgmstatus="Enable Music (Disabled)"

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ I am useing there work in my script.
 
 **2/3/19**
 Added: Bezel install now updates gamelist.xml 
+Added: Install to RetroPie executing script outside of the retropiemenu folder
+Added: script header
 Change: BGM function dowlnload busic if the ~/BGM folder doesn't exist
-Fixed: Hursty Themes original instal.sh crash due to scripts folder already existing, stopped using install.sh from            Hursty added to this script to check for the existance of folder. 
+Change: download music and icons so project doesn't have to be cloned
+Fixed: Hursty Themes original instal.sh crash due to scripts folder already existing, stopped using install.sh from            Hursty added to this script to check for the existence of folder. 
 
 **2/2/19**
 - Added: Hursty Themes Installer


### PR DESCRIPTION
**2/3/19**
Added: Bezel install now updates gamelist.xml
Added: Install to RetroPie executing script outside of the retropiemenu folder
Added: script header
Change: BGM function dowlnload busic if the ~/BGM folder doesn't exist
Change: download music and icons so project doesn't have to be cloned
Fixed: Hursty Themes original instal.sh crash due to scripts folder already existing, stopped using install.sh from            Hursty added to this script to check for the existence of folder.